### PR TITLE
Enable setting external alarm status

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ type API interface {
 	SetThreshold(context.Context, uuid.UUID, models.Threshold) error
 	PatchThreshold(context.Context, uuid.UUID, models.Patch) (models.Threshold, error)
 	GetAlarmStatus(context.Context, uuid.UUID) (models.AlarmStatus, error)
+	SetExternalAlarmStatus(context.Context, uuid.UUID, models.ExternalAlarmStatus) error
 }
 
 type Client struct {
@@ -110,6 +111,23 @@ func (c *Client) GetAlarmStatus(ctx context.Context, nodeID uuid.UUID) (alarmSta
 	}
 
 	alarmStatus.FromInternal(response)
+
+	return
+}
+
+func (c *Client) SetExternalAlarmStatus(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	status models.ExternalAlarmStatus,
+) (err error) {
+	payload := status.ToSetRequest()
+
+	request := rest.Put("v1/alarm-status/{nodeId}/status/external").
+		Assign("nodeId", nodeID).
+		WithJSONPayload(payload).
+		SetHeader("Accept", "application/json")
+
+	_, err = c.Do(ctx, request)
 
 	return
 }

--- a/client_test.go
+++ b/client_test.go
@@ -589,3 +589,34 @@ func Test_GetAlarmStatus_ErrorResponse(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func Test_SetExternalAlarmStatus(t *testing.T) {
+	setBy := uuid.EmptyUUID
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request internal_models.ModelsSetExternalAlarmStatusRequest
+
+		err := json.NewDecoder(r.Body).Decode(&request)
+		require.NoError(t, err)
+
+		if assert.NotNil(t, request.Status) {
+			assert.Equal(t, int32(models.AlarmStatusAlert), *request.Status)
+		}
+
+		if assert.NotNil(t, request.SetBy) {
+			assert.Equal(t, strfmt.UUID(uuid.EmptyUUID.String()), *request.SetBy)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(rest.WithBaseURL(server.URL))
+
+	err := client.SetExternalAlarmStatus(context.TODO(), uuid.EmptyUUID, models.ExternalAlarmStatus{
+		Status: models.AlarmStatusAlert,
+		SetBy:  &setBy,
+	})
+
+	assert.NoError(t, err)
+}

--- a/example/example.go
+++ b/example/example.go
@@ -51,6 +51,11 @@ func main() {
 
 	fmt.Println("The alarm status:")
 	getAlarmStatus(ctx, client, nodeID)
+
+	setExternalAlarmStatus(ctx, client, nodeID)
+
+	fmt.Println("The alarm status:")
+	getAlarmStatus(ctx, client, nodeID)
 }
 
 func print(data interface{}) {
@@ -114,4 +119,13 @@ func getAlarmStatus(ctx context.Context, client *pas.Client, nodeID uuid.UUID) {
 	}
 
 	print(alarmStatus)
+}
+
+func setExternalAlarmStatus(ctx context.Context, client *pas.Client, nodeID uuid.UUID) {
+	err := client.SetExternalAlarmStatus(ctx, nodeID, models.ExternalAlarmStatus{
+		Status: models.AlarmStatusAlert,
+	})
+	if err != nil {
+		panic(err)
+	}
 }

--- a/models/alarmstatus.go
+++ b/models/alarmstatus.go
@@ -3,6 +3,8 @@ package models
 import (
 	"time"
 
+	"github.com/go-openapi/strfmt"
+
 	models "github.com/SKF/go-pas-client/internal/models"
 	"github.com/SKF/go-utility/v2/uuid"
 )
@@ -121,6 +123,27 @@ func (e *ExternalAlarmStatus) FromInternal(internal *models.ModelsGetAlarmStatus
 		setBy := uuid.UUID(internal.SetBy.String())
 		e.SetBy = &setBy
 	}
+}
+
+func (e *ExternalAlarmStatus) ToSetRequest() models.ModelsSetExternalAlarmStatusRequest {
+	if e == nil {
+		return models.ModelsSetExternalAlarmStatusRequest{} // nolint:exhaustivestruct
+	}
+
+	status := int32(e.Status)
+
+	request := models.ModelsSetExternalAlarmStatusRequest{
+		Status: &status,
+		SetBy:  nil,
+	}
+
+	if e.SetBy != nil {
+		setBy := strfmt.UUID(e.SetBy.String())
+
+		request.SetBy = &setBy
+	}
+
+	return request
 }
 
 func (b *BandAlarmStatus) FromInternal(internal *models.ModelsGetAlarmStatusResponseBandAlarm) {

--- a/models/alarmstatus_test.go
+++ b/models/alarmstatus_test.go
@@ -500,6 +500,87 @@ func Test_ExternalAlarmStatus_IsNil(t *testing.T) {
 	})
 }
 
+func Test_ExternalAlarmStatus_ToSetRequest(t *testing.T) {
+	var (
+		setByStrfmt = strfmt.UUID(uuid.EmptyUUID.String())
+		setBy       = uuid.EmptyUUID
+	)
+
+	tests := []struct {
+		given    *ExternalAlarmStatus
+		expected models.ModelsSetExternalAlarmStatusRequest
+	}{
+		{
+			given: &ExternalAlarmStatus{
+				Status: AlarmStatusNotConfigured,
+			},
+			expected: models.ModelsSetExternalAlarmStatusRequest{
+				Status: i32p(0), // not configured
+			},
+		},
+		{
+			given: &ExternalAlarmStatus{
+				Status: AlarmStatusNoData,
+			},
+			expected: models.ModelsSetExternalAlarmStatusRequest{
+				Status: i32p(1), // no data
+			},
+		},
+		{
+			given: &ExternalAlarmStatus{
+				Status: AlarmStatusGood,
+			},
+			expected: models.ModelsSetExternalAlarmStatusRequest{
+				Status: i32p(2), // good
+			},
+		},
+		{
+			given: &ExternalAlarmStatus{
+				Status: AlarmStatusAlert,
+			},
+			expected: models.ModelsSetExternalAlarmStatusRequest{
+				Status: i32p(3), // alert
+			},
+		},
+		{
+			given: &ExternalAlarmStatus{
+				Status: AlarmStatusDanger,
+			},
+			expected: models.ModelsSetExternalAlarmStatusRequest{
+				Status: i32p(4), // danger
+			},
+		},
+		{
+			given: &ExternalAlarmStatus{
+				Status: AlarmStatusGood,
+				SetBy:  &setBy,
+			},
+			expected: models.ModelsSetExternalAlarmStatusRequest{
+				Status: i32p(2), // good
+				SetBy:  &setByStrfmt,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run("", func(t *testing.T) {
+			actual := test.given.ToSetRequest()
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_ExternalAlarmStatus_ToSetRequest_IsNil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		var status *ExternalAlarmStatus
+
+		_ = status.ToSetRequest()
+	})
+}
+
 func Test_BandAlarmStatus(t *testing.T) {
 	tests := []struct {
 		given    *models.ModelsGetAlarmStatusResponseBandAlarm


### PR DESCRIPTION
Adds a client function that can be used to set the external alarm status on a point.