### PR TITLE
Add function to update alarm status

### DIFF
--- a/client.go
+++ b/client.go
@@ -115,6 +115,23 @@ func (c *Client) GetAlarmStatus(ctx context.Context, nodeID uuid.UUID) (alarmSta
 	return
 }
 
+func (c *Client) UpdateAlarmStatus(
+	ctx context.Context,
+	nodeID uuid.UUID,
+	measurement models.Measurement,
+) (err error) {
+	payload := measurement.ToInternal()
+
+	request := rest.Put("v1/alarm-status/{nodeId}").
+		Assign("nodeId", nodeID).
+		WithJSONPayload(payload).
+		SetHeader("Accept", "application/json")
+
+	_, err = c.Do(ctx, request)
+
+	return
+}
+
 func (c *Client) SetExternalAlarmStatus(
 	ctx context.Context,
 	nodeID uuid.UUID,

--- a/example/example.go
+++ b/example/example.go
@@ -54,6 +54,8 @@ func main() {
 
 	setExternalAlarmStatus(ctx, client, nodeID)
 
+	updateAlarmStatus(ctx, client, nodeID)
+
 	fmt.Println("The alarm status:")
 	getAlarmStatus(ctx, client, nodeID)
 }
@@ -121,9 +123,34 @@ func getAlarmStatus(ctx context.Context, client *pas.Client, nodeID uuid.UUID) {
 	print(alarmStatus)
 }
 
+func updateAlarmStatus(ctx context.Context, client *pas.Client, nodeID uuid.UUID) {
+	createdAt := time.Now().Add(-time.Minute).UTC()
+	measurement := models.Measurement{
+		CreatedAt:     createdAt,
+		MeasurementID: uuid.EmptyUUID,
+		ContentType:   models.ContentTypeDataPoint,
+		DataPoint: &models.DataPoint{
+			Coordinate: models.Coordinate{
+				X: float64(createdAt.UnixMilli()),
+				Y: 65,
+			},
+			XUnit: "ms",
+			YUnit: "C",
+		},
+		Tags: map[string]interface{}{
+			"source": "unit-test",
+		},
+	}
+
+	err := client.UpdateAlarmStatus(ctx, nodeID, measurement)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func setExternalAlarmStatus(ctx context.Context, client *pas.Client, nodeID uuid.UUID) {
 	err := client.SetExternalAlarmStatus(ctx, nodeID, models.ExternalAlarmStatus{
-		Status: models.AlarmStatusAlert,
+		Status: models.AlarmStatusDanger,
 	})
 	if err != nil {
 		panic(err)

--- a/models/measurement.go
+++ b/models/measurement.go
@@ -1,0 +1,98 @@
+package models
+
+import (
+	"time"
+
+	"github.com/go-openapi/strfmt"
+
+	models "github.com/SKF/go-pas-client/internal/models"
+	"github.com/SKF/go-utility/v2/uuid"
+)
+
+type ContentType string
+
+const (
+	ContentTypeDataPoint       ContentType = "DATA_POINT"
+	ContentTypeSpectrum        ContentType = "SPECTRUM"
+	ContentTypeQuestionAnswers ContentType = "QUESTION_ANSWERS"
+)
+
+type (
+	Measurement struct {
+		MeasurementID   uuid.UUID
+		CreatedAt       time.Time
+		ContentType     ContentType
+		DataPoint       *DataPoint
+		Spectrum        *Spectrum
+		QuestionAnswers []string
+		RateOfChange    *float64
+		Tags            map[string]interface{}
+	}
+
+	Coordinate struct {
+		X float64
+		Y float64
+	}
+
+	DataPoint struct {
+		Coordinate Coordinate
+		XUnit      string
+		YUnit      string
+	}
+
+	Spectrum struct {
+		XUnit string
+		YUnit string
+		Speed float64
+	}
+)
+
+func (m *Measurement) ToInternal() models.ModelsUpdateAlarmStatusRequest {
+	if m == nil {
+		return models.ModelsUpdateAlarmStatusRequest{} // nolint:exhaustivestruct
+	}
+
+	var (
+		measurementID = strfmt.UUID(m.MeasurementID.String())
+		createdAt     = strfmt.DateTime(m.CreatedAt)
+		contentType   = string(m.ContentType)
+	)
+
+	internal := models.ModelsUpdateAlarmStatusRequest{
+		MeasurementID:   &measurementID,
+		CreatedAt:       &createdAt,
+		ContentType:     &contentType,
+		RateOfChange:    m.RateOfChange,
+		DataPoint:       nil,
+		Spectrum:        nil,
+		QuestionAnswers: nil,
+		Tags:            m.Tags,
+	}
+
+	if length := len(m.QuestionAnswers); length > 0 {
+		internal.QuestionAnswers = make([]string, length)
+
+		copy(internal.QuestionAnswers, m.QuestionAnswers)
+	}
+
+	if m.DataPoint != nil {
+		internal.DataPoint = &models.ModelsDataPoint{
+			XUnit: &m.DataPoint.XUnit,
+			YUnit: &m.DataPoint.YUnit,
+			Coordinate: &models.ModelsCoordinate{
+				X: &m.DataPoint.Coordinate.X,
+				Y: &m.DataPoint.Coordinate.Y,
+			},
+		}
+	}
+
+	if m.Spectrum != nil {
+		internal.Spectrum = &models.ModelsSpectrum{
+			XUnit: &m.Spectrum.XUnit,
+			YUnit: &m.Spectrum.YUnit,
+			Speed: &m.Spectrum.Speed,
+		}
+	}
+
+	return internal
+}

--- a/models/measurement_test.go
+++ b/models/measurement_test.go
@@ -1,0 +1,137 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+
+	models "github.com/SKF/go-pas-client/internal/models"
+	"github.com/SKF/go-utility/v2/uuid"
+)
+
+func strfmtDateTimep(d strfmt.DateTime) *strfmt.DateTime {
+	return &d
+}
+
+func strfmtUUIDp(u strfmt.UUID) *strfmt.UUID {
+	return &u
+}
+
+func Test_Measurement_ToInternal(t *testing.T) {
+	var (
+		now           = time.UnixMilli(time.Now().UnixMilli()).UTC()
+		measurementID = uuid.EmptyUUID
+	)
+
+	tests := []struct {
+		given    *Measurement
+		expected models.ModelsUpdateAlarmStatusRequest
+	}{
+		{
+			given: &Measurement{
+				CreatedAt:     now,
+				MeasurementID: measurementID,
+				ContentType:   ContentTypeDataPoint,
+				DataPoint: &DataPoint{
+					Coordinate: Coordinate{
+						X: float64(now.UnixMilli()),
+						Y: 10.0,
+					},
+					XUnit: "ms",
+					YUnit: "gE",
+				},
+				Tags: map[string]interface{}{
+					"source": "unit-test",
+				},
+			},
+			expected: models.ModelsUpdateAlarmStatusRequest{
+				CreatedAt:     strfmtDateTimep(strfmt.DateTime(now)),
+				MeasurementID: strfmtUUIDp(strfmt.UUID(measurementID.String())),
+				ContentType:   stringp("DATA_POINT"),
+				DataPoint: &models.ModelsDataPoint{
+					Coordinate: &models.ModelsCoordinate{
+						X: f64p(float64(now.UnixMilli())),
+						Y: f64p(10.0),
+					},
+					XUnit: stringp("ms"),
+					YUnit: stringp("gE"),
+				},
+				Tags: map[string]interface{}{
+					"source": "unit-test",
+				},
+			},
+		},
+		{
+			given: &Measurement{
+				CreatedAt:     now,
+				MeasurementID: measurementID,
+				ContentType:   ContentTypeSpectrum,
+				Spectrum: &Spectrum{
+					XUnit: "ms",
+					YUnit: "gE",
+					Speed: 1780.02,
+				},
+				Tags: map[string]interface{}{
+					"source": "unit-test",
+				},
+			},
+			expected: models.ModelsUpdateAlarmStatusRequest{
+				CreatedAt:     strfmtDateTimep(strfmt.DateTime(now)),
+				MeasurementID: strfmtUUIDp(strfmt.UUID(measurementID.String())),
+				ContentType:   stringp("SPECTRUM"),
+				Spectrum: &models.ModelsSpectrum{
+					XUnit: stringp("ms"),
+					YUnit: stringp("gE"),
+					Speed: f64p(1780.02),
+				},
+				Tags: map[string]interface{}{
+					"source": "unit-test",
+				},
+			},
+		},
+		{
+			given: &Measurement{
+				CreatedAt:     now,
+				MeasurementID: measurementID,
+				ContentType:   ContentTypeQuestionAnswers,
+				QuestionAnswers: []string{
+					"good",
+				},
+				Tags: map[string]interface{}{
+					"source": "unit-test",
+				},
+			},
+			expected: models.ModelsUpdateAlarmStatusRequest{
+				CreatedAt:     strfmtDateTimep(strfmt.DateTime(now)),
+				MeasurementID: strfmtUUIDp(strfmt.UUID(measurementID.String())),
+				ContentType:   stringp("QUESTION_ANSWERS"),
+				QuestionAnswers: []string{
+					"good",
+				},
+				Tags: map[string]interface{}{
+					"source": "unit-test",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run("", func(t *testing.T) {
+			actual := test.given.ToInternal()
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_Measurement_ToInternal_IsNil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		var m *Measurement
+
+		_ = m.ToInternal()
+	})
+}


### PR DESCRIPTION
Adds a client function which takes a measurement, and calls the PAS API to update the alarm status using the given data.