### PR TITLE
Fix/reference to iterator variable causes pointer problems

### DIFF
--- a/models/bandalarm.go
+++ b/models/bandalarm.go
@@ -51,11 +51,7 @@ func (b *BandAlarm) FromInternal(internal *models.ModelsBandAlarm) {
 	}
 }
 
-func (b *BandAlarm) ToInternal() *models.ModelsBandAlarm {
-	if b == nil {
-		return nil
-	}
-
+func (b BandAlarm) ToInternal() *models.ModelsBandAlarm {
 	return &models.ModelsBandAlarm{
 		Label:            b.Label,
 		OverallThreshold: b.OverallThreshold.ToInternal(),

--- a/models/bandalarm.go
+++ b/models/bandalarm.go
@@ -52,12 +52,18 @@ func (b *BandAlarm) FromInternal(internal *models.ModelsBandAlarm) {
 }
 
 func (b BandAlarm) ToInternal() *models.ModelsBandAlarm {
-	return &models.ModelsBandAlarm{
+	bandAlarm := &models.ModelsBandAlarm{
 		Label:            b.Label,
-		OverallThreshold: b.OverallThreshold.ToInternal(),
+		OverallThreshold: nil,
 		MinFrequency:     b.MinFrequency.ToInternal(),
 		MaxFrequency:     b.MaxFrequency.ToInternal(),
 	}
+
+	if b.OverallThreshold != nil {
+		bandAlarm.OverallThreshold = b.OverallThreshold.ToInternal()
+	}
+
+	return bandAlarm
 }
 
 func (b *BandAlarm) FromProto(buf []byte) error {
@@ -111,11 +117,7 @@ func (f *BandAlarmFrequency) FromInternalAlarmStatus(internal *models.ModelsGetA
 	}
 }
 
-func (f *BandAlarmFrequency) ToInternal() *models.ModelsBandAlarmFrequency {
-	if f == nil {
-		return nil
-	}
-
+func (f BandAlarmFrequency) ToInternal() *models.ModelsBandAlarmFrequency {
 	valueType := int32(f.ValueType)
 
 	return &models.ModelsBandAlarmFrequency{
@@ -154,16 +156,22 @@ func (b *BandAlarmOverallThreshold) FromInternal(internal *models.ModelsBandAlar
 	}
 }
 
-func (b *BandAlarmOverallThreshold) ToInternal() *models.ModelsBandAlarmOverallThreshold {
-	if b == nil {
-		return nil
+func (b BandAlarmOverallThreshold) ToInternal() *models.ModelsBandAlarmOverallThreshold {
+	threshold := &models.ModelsBandAlarmOverallThreshold{
+		Unit:        b.Unit,
+		UpperAlert:  nil,
+		UpperDanger: nil,
 	}
 
-	return &models.ModelsBandAlarmOverallThreshold{
-		Unit:        b.Unit,
-		UpperAlert:  b.UpperAlert.ToInternal(),
-		UpperDanger: b.UpperDanger.ToInternal(),
+	if b.UpperAlert != nil {
+		threshold.UpperAlert = b.UpperAlert.ToInternal()
 	}
+
+	if b.UpperDanger != nil {
+		threshold.UpperDanger = b.UpperDanger.ToInternal()
+	}
+
+	return threshold
 }
 
 func (b *BandAlarmOverallThreshold) FromProto(internal *pas.BandAlarmOverallThreshold) {
@@ -198,11 +206,7 @@ func (t *BandAlarmThreshold) FromInternal(internal *models.ModelsBandAlarmThresh
 	}
 }
 
-func (t *BandAlarmThreshold) ToInternal() *models.ModelsBandAlarmThreshold {
-	if t == nil {
-		return nil
-	}
-
+func (t BandAlarmThreshold) ToInternal() *models.ModelsBandAlarmThreshold {
 	valueType := int32(t.ValueType)
 
 	return &models.ModelsBandAlarmThreshold{

--- a/models/bandalarm_test.go
+++ b/models/bandalarm_test.go
@@ -400,18 +400,6 @@ func Test_BandAlarm_ToInternal(t *testing.T) {
 	}
 }
 
-func Test_BandAlarm_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var bandAlarm *BandAlarm
-
-		actual := bandAlarm.ToInternal()
-
-		assert.Nil(t, actual)
-	})
-}
-
 func Test_BandAlarm_FromProto(t *testing.T) {
 	t.Parallel()
 

--- a/models/bandalarm_test.go
+++ b/models/bandalarm_test.go
@@ -204,10 +204,6 @@ func Test_BandAlarm_ToInternal(t *testing.T) {
 		expected *models.ModelsBandAlarm
 	}{
 		{
-			given:    nil,
-			expected: nil,
-		},
-		{
 			given: &BandAlarm{
 				MaxFrequency: BandAlarmFrequency{
 					ValueType: BandAlarmFrequencyFixed,

--- a/models/bandalarm_test.go
+++ b/models/bandalarm_test.go
@@ -640,18 +640,6 @@ func Test_BandAlarmFrequency_FromInternalAlarmStatus_IsNil(t *testing.T) {
 	})
 }
 
-func Test_BandAlarmFrequency_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var frequency *BandAlarmFrequency
-
-		actual := frequency.ToInternal()
-
-		assert.Nil(t, actual)
-	})
-}
-
 func Test_BandAlarmFrequency_FromProto_IsNil(t *testing.T) {
 	t.Parallel()
 
@@ -800,10 +788,6 @@ func Test_BandAlarmOverallThreshold_ToInternal(t *testing.T) {
 		expected *models.ModelsBandAlarmOverallThreshold
 	}{
 		{
-			given:    nil,
-			expected: nil,
-		},
-		{
 			given:    &BandAlarmOverallThreshold{},
 			expected: &models.ModelsBandAlarmOverallThreshold{},
 		},
@@ -874,18 +858,6 @@ func Test_BandAlarmOverallThreshold_ToInternal(t *testing.T) {
 			assert.Equal(t, test.expected, actual)
 		})
 	}
-}
-
-func Test_BandAlarmOverallThreshold_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var threshold *BandAlarmOverallThreshold
-
-		actual := threshold.ToInternal()
-
-		assert.Nil(t, actual)
-	})
 }
 
 func Test_BandAlarmOverallThreshold_FromProto(t *testing.T) {
@@ -1003,18 +975,6 @@ func Test_BandAlarmThreshold_FromInternal_IsNil(t *testing.T) {
 		threshold := new(BandAlarmThreshold)
 
 		threshold.FromInternal(nil)
-	})
-}
-
-func Test_BandAlarmThreshold_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var threshold *BandAlarmThreshold
-
-		actual := threshold.ToInternal()
-
-		assert.Nil(t, actual)
 	})
 }
 

--- a/models/halalarm.go
+++ b/models/halalarm.go
@@ -44,11 +44,7 @@ func (h *HALAlarm) FromInternal(internal *models.ModelsHALAlarm) {
 	}
 }
 
-func (h *HALAlarm) ToInternal() *models.ModelsHALAlarm {
-	if h == nil {
-		return nil
-	}
-
+func (h HALAlarm) ToInternal() *models.ModelsHALAlarm {
 	halAlarm := &models.ModelsHALAlarm{
 		Label:        h.Label,
 		HalAlarmType: string(h.HALAlarmType),
@@ -58,13 +54,17 @@ func (h *HALAlarm) ToInternal() *models.ModelsHALAlarm {
 	}
 
 	if h.Bearing != nil {
-		halAlarm.Bearing = &models.ModelsBearing{
-			Manufacturer: &h.Bearing.Manufacturer,
-			ModelNumber:  &h.Bearing.ModelNumber,
-		}
+		halAlarm.Bearing = h.Bearing.ToInternal()
 	}
 
 	return halAlarm
+}
+
+func (b Bearing) ToInternal() *models.ModelsBearing {
+	return &models.ModelsBearing{
+		Manufacturer: &b.Manufacturer,
+		ModelNumber:  &b.ModelNumber,
+	}
 }
 
 func (h *HALAlarm) FromProto(buf []byte) error {

--- a/models/halalarm_test.go
+++ b/models/halalarm_test.go
@@ -125,10 +125,6 @@ func Test_HALAlarm_ToInternal(t *testing.T) {
 		expected *models.ModelsHALAlarm
 	}{
 		{
-			given:    nil,
-			expected: nil,
-		},
-		{
 			given:    &HALAlarm{},
 			expected: &models.ModelsHALAlarm{},
 		},
@@ -199,18 +195,6 @@ func Test_HALAlarm_ToInternal(t *testing.T) {
 			assert.Equal(t, test.expected, actual)
 		})
 	}
-}
-
-func Test_HALAlarm_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var halAlarm *HALAlarm
-
-		actual := halAlarm.ToInternal()
-
-		assert.Nil(t, actual)
-	})
 }
 
 func Test_HALAlarm_FromProto(t *testing.T) {

--- a/models/inspection.go
+++ b/models/inspection.go
@@ -46,27 +46,19 @@ func (i *InspectionChoice) FromInternal(internal *models.ModelsInspectionChoice)
 	}
 }
 
-func (i *Inspection) ToInternal() *models.ModelsInspection {
-	if i == nil {
-		return nil
-	}
-
+func (i Inspection) ToInternal() *models.ModelsInspection {
 	inspection := &models.ModelsInspection{
-		Choices: make([]*models.ModelsInspectionChoice, 0, len(i.Choices)),
+		Choices: make([]*models.ModelsInspectionChoice, len(i.Choices)),
 	}
 
-	for _, choice := range i.Choices {
-		inspection.Choices = append(inspection.Choices, choice.ToInternal())
+	for i, choice := range i.Choices {
+		inspection.Choices[i] = choice.ToInternal()
 	}
 
 	return inspection
 }
 
-func (i *InspectionChoice) ToInternal() *models.ModelsInspectionChoice {
-	if i == nil {
-		return nil
-	}
-
+func (i InspectionChoice) ToInternal() *models.ModelsInspectionChoice {
 	status := int32(i.Status)
 
 	return &models.ModelsInspectionChoice{

--- a/models/inspection_test.go
+++ b/models/inspection_test.go
@@ -162,10 +162,6 @@ func Test_Inspection_ToInternal(t *testing.T) {
 		expected *models.ModelsInspection
 	}{
 		{
-			given:    nil,
-			expected: nil,
-		},
-		{
 			given: &Inspection{
 				Choices: []InspectionChoice{},
 			},
@@ -264,18 +260,6 @@ func Test_Inspection_ToInternal(t *testing.T) {
 			assert.Equal(t, test.expected, actual)
 		})
 	}
-}
-
-func Test_InspectionChoice_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var choice *InspectionChoice
-
-		actual := choice.ToInternal()
-
-		assert.Nil(t, actual)
-	})
 }
 
 func Test_InspectionChoice_FromProto(t *testing.T) {

--- a/models/overall.go
+++ b/models/overall.go
@@ -30,11 +30,7 @@ func (o *Overall) FromInternal(internal *models.ModelsOverall) {
 	o.OuterLow = internal.OuterLow
 }
 
-func (o *Overall) ToInternal() *models.ModelsOverall {
-	if o == nil {
-		return nil
-	}
-
+func (o Overall) ToInternal() *models.ModelsOverall {
 	return &models.ModelsOverall{
 		Unit:      o.Unit,
 		OuterHigh: o.OuterHigh,

--- a/models/overall_test.go
+++ b/models/overall_test.go
@@ -89,10 +89,6 @@ func Test_Overall_ToInternal(t *testing.T) {
 		expected *models.ModelsOverall
 	}{
 		{
-			given:    nil,
-			expected: nil,
-		},
-		{
 			given:    &Overall{},
 			expected: &models.ModelsOverall{},
 		},
@@ -131,18 +127,6 @@ func Test_Overall_ToInternal(t *testing.T) {
 			assert.Equal(t, test.expected, actual)
 		})
 	}
-}
-
-func Test_Overall_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var overall *Overall
-
-		actual := overall.ToInternal()
-
-		assert.Nil(t, actual)
-	})
 }
 
 func Test_Overall_Convert(t *testing.T) {

--- a/models/rateofchange.go
+++ b/models/rateofchange.go
@@ -30,11 +30,7 @@ func (r *RateOfChange) FromInternal(internal *models.ModelsRateOfChange) {
 	r.OuterLow = internal.OuterLow
 }
 
-func (r *RateOfChange) ToInternal() *models.ModelsRateOfChange {
-	if r == nil {
-		return nil
-	}
-
+func (r RateOfChange) ToInternal() *models.ModelsRateOfChange {
 	return &models.ModelsRateOfChange{
 		Unit:      r.Unit,
 		OuterHigh: r.OuterHigh,

--- a/models/rateofchange_test.go
+++ b/models/rateofchange_test.go
@@ -89,10 +89,6 @@ func Test_RateOfChange_ToInternal(t *testing.T) {
 		expected *models.ModelsRateOfChange
 	}{
 		{
-			given:    nil,
-			expected: nil,
-		},
-		{
 			given:    &RateOfChange{},
 			expected: &models.ModelsRateOfChange{},
 		},
@@ -131,18 +127,6 @@ func Test_RateOfChange_ToInternal(t *testing.T) {
 			assert.Equal(t, test.expected, actual)
 		})
 	}
-}
-
-func Test_RateOfChange_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var rateOfChange *RateOfChange
-
-		actual := rateOfChange.ToInternal()
-
-		assert.Nil(t, actual)
-	})
 }
 
 func Test_RateOfChange_Convert(t *testing.T) {

--- a/models/threshold.go
+++ b/models/threshold.go
@@ -65,22 +65,30 @@ func (t *Threshold) FromInternal(internal models.ModelsGetPointAlarmThresholdRes
 	return nil
 }
 
-func (t *Threshold) ToInternal() models.ModelsSetPointAlarmThresholdRequest {
-	if t == nil {
-		return models.ModelsSetPointAlarmThresholdRequest{} // nolint:exhaustivestruct
-	}
-
+func (t Threshold) ToInternal() models.ModelsSetPointAlarmThresholdRequest {
 	thresholdType := int32(t.ThresholdType)
 
 	threshold := models.ModelsSetPointAlarmThresholdRequest{
 		Origin:        nil,
 		ThresholdType: &thresholdType,
-		Overall:       t.Overall.ToInternal(),
-		RateOfChange:  t.RateOfChange.ToInternal(),
-		Inspection:    t.Inspection.ToInternal(),
 		FullScale:     t.FullScale,
+		Overall:       nil,
+		RateOfChange:  nil,
+		Inspection:    nil,
 		BandAlarms:    make([]*models.ModelsBandAlarm, len(t.BandAlarms)),
 		HalAlarms:     make([]*models.ModelsHALAlarm, len(t.HALAlarms)),
+	}
+
+	if t.Overall != nil {
+		threshold.Overall = t.Overall.ToInternal()
+	}
+
+	if t.RateOfChange != nil {
+		threshold.RateOfChange = t.RateOfChange.ToInternal()
+	}
+
+	if t.Inspection != nil {
+		threshold.Inspection = t.Inspection.ToInternal()
 	}
 
 	for i, bandAlarm := range t.BandAlarms {

--- a/models/threshold_test.go
+++ b/models/threshold_test.go
@@ -393,6 +393,158 @@ func Test_Threshold_ToInternal(t *testing.T) {
 				},
 			},
 		},
+		{
+			given: &Threshold{
+				BandAlarms: []BandAlarm{
+					{
+						OverallThreshold: &BandAlarmOverallThreshold{
+							UpperAlert: &BandAlarmThreshold{
+								ValueType: BandAlarmThresholdTypeAbsolute,
+								Value:     10,
+							},
+							UpperDanger: &BandAlarmThreshold{
+								ValueType: BandAlarmThresholdTypeAbsolute,
+								Value:     20,
+							},
+							Unit: "gE",
+						},
+						Label: "foo",
+						MinFrequency: BandAlarmFrequency{
+							ValueType: BandAlarmFrequencyFixed,
+							Value:     1,
+						},
+						MaxFrequency: BandAlarmFrequency{
+							ValueType: BandAlarmFrequencyFixed,
+							Value:     2,
+						},
+					},
+					{
+						OverallThreshold: &BandAlarmOverallThreshold{
+							UpperAlert: &BandAlarmThreshold{
+								ValueType: BandAlarmThresholdTypeRelativeFullscale,
+								Value:     100,
+							},
+							UpperDanger: &BandAlarmThreshold{
+								ValueType: BandAlarmThresholdTypeRelativeFullscale,
+								Value:     200,
+							},
+							Unit: "gE",
+						},
+						Label: "bar",
+						MinFrequency: BandAlarmFrequency{
+							ValueType: BandAlarmFrequencySpeedMultiple,
+							Value:     10,
+						},
+						MaxFrequency: BandAlarmFrequency{
+							ValueType: BandAlarmFrequencySpeedMultiple,
+							Value:     22,
+						},
+					},
+				},
+			},
+			expected: models.ModelsSetPointAlarmThresholdRequest{
+				ThresholdType: i32p(0),
+				BandAlarms: []*models.ModelsBandAlarm{
+					{
+						OverallThreshold: &models.ModelsBandAlarmOverallThreshold{
+							UpperAlert: &models.ModelsBandAlarmThreshold{
+								ValueType: i32p(int32(BandAlarmThresholdTypeAbsolute)),
+								Value:     f64p(10),
+							},
+							UpperDanger: &models.ModelsBandAlarmThreshold{
+								ValueType: i32p(int32(BandAlarmThresholdTypeAbsolute)),
+								Value:     f64p(20),
+							},
+							Unit: "gE",
+						},
+						Label: "foo",
+						MinFrequency: &models.ModelsBandAlarmFrequency{
+							ValueType: i32p(int32(BandAlarmFrequencyFixed)),
+							Value:     f64p(1),
+						},
+						MaxFrequency: &models.ModelsBandAlarmFrequency{
+							ValueType: i32p(int32(BandAlarmFrequencyFixed)),
+							Value:     f64p(2),
+						},
+					},
+					{
+						OverallThreshold: &models.ModelsBandAlarmOverallThreshold{
+							UpperAlert: &models.ModelsBandAlarmThreshold{
+								ValueType: i32p(int32(BandAlarmThresholdTypeRelativeFullscale)),
+								Value:     f64p(100),
+							},
+							UpperDanger: &models.ModelsBandAlarmThreshold{
+								ValueType: i32p(int32(BandAlarmThresholdTypeRelativeFullscale)),
+								Value:     f64p(200),
+							},
+							Unit: "gE",
+						},
+						Label: "bar",
+						MinFrequency: &models.ModelsBandAlarmFrequency{
+							ValueType: i32p(int32(BandAlarmFrequencySpeedMultiple)),
+							Value:     f64p(10),
+						},
+						MaxFrequency: &models.ModelsBandAlarmFrequency{
+							ValueType: i32p(int32(BandAlarmFrequencySpeedMultiple)),
+							Value:     f64p(22),
+						},
+					},
+				},
+				HalAlarms: []*models.ModelsHALAlarm{},
+			},
+		},
+		{
+			given: &Threshold{
+				HALAlarms: []HALAlarm{
+					{
+						Label: "abc",
+						Bearing: &Bearing{
+							Manufacturer: "foo",
+							ModelNumber:  "bar",
+						},
+						HALAlarmType: HALAlarmTypeGlobal,
+						UpperDanger:  f64p(100),
+						UpperAlert:   f64p(50),
+					},
+					{
+						Label: "def",
+						Bearing: &Bearing{
+							Manufacturer: "bar",
+							ModelNumber:  "foo",
+						},
+						HALAlarmType: HALAlarmTypeFaultFrequency,
+						UpperDanger:  f64p(101),
+						UpperAlert:   f64p(51),
+					},
+				},
+			},
+			expected: models.ModelsSetPointAlarmThresholdRequest{
+				ThresholdType: i32p(0),
+				BandAlarms:    []*models.ModelsBandAlarm{},
+				HalAlarms: []*models.ModelsHALAlarm{
+					{
+						Bearing: &models.ModelsBearing{
+							Manufacturer: stringp("foo"),
+							ModelNumber:  stringp("bar"),
+						},
+						HalAlarmType: string(HALAlarmTypeGlobal),
+						Label:        "abc",
+						UpperAlert:   f64p(50),
+						UpperDanger:  f64p(100),
+					},
+					{
+						Bearing: &models.ModelsBearing{
+							Manufacturer: stringp("bar"),
+							ModelNumber:  stringp("foo"),
+						},
+						HalAlarmType: string(HALAlarmTypeFaultFrequency),
+						Label:        "def",
+						UpperAlert:   f64p(51),
+						UpperDanger:  f64p(101),
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/models/threshold_test.go
+++ b/models/threshold_test.go
@@ -557,17 +557,3 @@ func Test_Threshold_ToInternal(t *testing.T) {
 		})
 	}
 }
-
-func Test_Threshold_ToInternal_IsNil(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() {
-		var threshold *Threshold
-
-		expected := models.ModelsSetPointAlarmThresholdRequest{}
-
-		actual := threshold.ToInternal()
-
-		assert.Equal(t, expected, actual)
-	})
-}


### PR DESCRIPTION
In go-pas-client we convert the public models from the user to the interal models used for the actual request. In this conversion, when converting the band alarms list we do this:
```
for i, bandAlarm := range t.BandAlarms {
   threshold.BandAlarms[i] = bandAlarm.ToInternal()
}
```
This causes a problem when the ToInternal function on bandAlarm operates on a pointer to the struct rather than the struct itself. The function return an object with values that point back into the iterator variable and when we have more than one item in the list these values are set to the last value that was set in the iterator variable.