### PR TITLE
Fix Update Alarm Status

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ type API interface {
 	PatchThreshold(context.Context, uuid.UUID, models.Patch) (models.Threshold, error)
 	GetAlarmStatus(context.Context, uuid.UUID) (models.AlarmStatus, error)
 	SetExternalAlarmStatus(context.Context, uuid.UUID, models.ExternalAlarmStatus) error
+	UpdateAlarmStatus(context.Context, uuid.UUID, *models.Measurement) error
 }
 
 type Client struct {
@@ -119,14 +120,15 @@ func (c *Client) GetAlarmStatus(ctx context.Context, nodeID uuid.UUID) (alarmSta
 func (c *Client) UpdateAlarmStatus(
 	ctx context.Context,
 	nodeID uuid.UUID,
-	measurement models.Measurement,
+	measurement *models.Measurement,
 ) (err error) {
-	payload := measurement.ToInternal()
-
 	request := rest.Put("v1/alarm-status/{nodeId}").
 		Assign("nodeId", nodeID).
-		WithJSONPayload(payload).
 		SetHeader("Accept", "application/json")
+
+	if measurement != nil {
+		request.WithJSONPayload(measurement.ToInternal())
+	}
 
 	_, err = c.Do(ctx, request)
 

--- a/client_test.go
+++ b/client_test.go
@@ -670,7 +670,21 @@ func Test_UpdateAlarmStatus(t *testing.T) {
 
 	client := New(rest.WithBaseURL(server.URL))
 
-	err := client.UpdateAlarmStatus(context.TODO(), uuid.EmptyUUID, given)
+	err := client.UpdateAlarmStatus(context.TODO(), uuid.EmptyUUID, &given)
+	require.NoError(t, err)
+}
+
+func Test_UpdateAlarmStatus_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(rest.WithBaseURL(server.URL))
+
+	err := client.UpdateAlarmStatus(context.TODO(), uuid.EmptyUUID, nil)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
The update alarm status function does not allow to send update requests without a body. This makes it impossible to update the alarm based on the existing threshold and measurement.

Change the signature of the function and the implementation to allow to send the request without a request body.