### PR TITLE
Fix decoding internal server errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func (c *Client) PatchThreshold(ctx context.Context, nodeID uuid.UUID, patch mod
 	var response internal_models.ModelsGetPointAlarmThresholdResponse
 
 	if err := c.DoAndUnmarshal(ctx, request, &response); err != nil {
-		return models.Threshold{}, fmt.Errorf("getting threshold failed: %w", err)
+		return models.Threshold{}, fmt.Errorf("patching threshold failed: %w", err)
 	}
 
 	threshold := models.Threshold{} // nolint:exhaustivestruct

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/SKF/go-pas-client
 go 1.17
 
 require (
-	github.com/SKF/go-eventsource/v2 v2.12.1
-	github.com/SKF/go-rest-utility v0.9.0
-	github.com/SKF/go-utility/v2 v2.25.3
+	github.com/SKF/go-eventsource/v2 v2.13.0
+	github.com/SKF/go-rest-utility v0.10.2
+	github.com/SKF/go-utility/v2 v2.29.0
 	github.com/SKF/proto/v2 v2.18.0-go
 	github.com/go-openapi/errors v0.20.2
 	github.com/go-openapi/strfmt v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,12 @@ github.com/SKF/go-eventsource v1.4.2 h1:c6xQc36EgxmffbjQMxhe9rsCMCfgOI7ZllQJ4Qj/
 github.com/SKF/go-eventsource v1.4.2/go.mod h1:iFoudpu5x2oj7LkiUAslraR0RUbJcScosdAWwxmDVds=
 github.com/SKF/go-eventsource/v2 v2.12.1 h1:EMXROTXi/rttgz3Pwe8LIqwCRNC2smL/flQ/F3XzxYA=
 github.com/SKF/go-eventsource/v2 v2.12.1/go.mod h1:zTsSyBtuLEqbF83f/yYML6JPaiS2aNJLnKgcAqtt04k=
+github.com/SKF/go-eventsource/v2 v2.13.0 h1:AvOr24bzVCl1jAUsX8UeLGe7NHIwXPBFJOXqd5MWzpw=
+github.com/SKF/go-eventsource/v2 v2.13.0/go.mod h1:zTsSyBtuLEqbF83f/yYML6JPaiS2aNJLnKgcAqtt04k=
 github.com/SKF/go-rest-utility v0.3.0/go.mod h1:h8g/3fX46d6omkbY8vgwUITXFLzh44S3GZX4jGfqMKQ=
 github.com/SKF/go-rest-utility v0.5.0/go.mod h1:yFHIQRiZpjQf2d43vuHbzXtKhT4l+FuQcuZMZIgFB/E=
-github.com/SKF/go-rest-utility v0.9.0 h1:gXcsyOhfqsWmqlbJYyIpG0PMdvFYlxE4Ws1GckDNpXE=
-github.com/SKF/go-rest-utility v0.9.0/go.mod h1:k5+4TrtQFUTenRsbxgLu/KhOkaaLaoblaS93JLy0Q30=
+github.com/SKF/go-rest-utility v0.10.2 h1:qeT3iKTOIa6YmNE4MXRiT2VlrahHQLlKdpn6WPOLFls=
+github.com/SKF/go-rest-utility v0.10.2/go.mod h1:k5+4TrtQFUTenRsbxgLu/KhOkaaLaoblaS93JLy0Q30=
 github.com/SKF/go-utility v1.10.2/go.mod h1:mxUVUqPwoJ2+kukhYImgcBP5maSCIZ4g9tzwjY1wjGk=
 github.com/SKF/go-utility v1.10.4 h1:/ANSV7G7cRgnjdrdMhsSY7Z5eoJibSihMBO0YQDS1ag=
 github.com/SKF/go-utility v1.10.4/go.mod h1:7gG7T9bnq8N3YViQfefxrpz/OAoME99oDkpGc/wkwhk=
@@ -43,6 +45,8 @@ github.com/SKF/go-utility/v2 v2.24.0/go.mod h1:lPJAVtRO4lV/Gg8AGogofBNrdvQSl1TUI
 github.com/SKF/go-utility/v2 v2.25.2/go.mod h1:vNsxDA+tBxVW1AuQmCI3GoZu4RNG76bt6as4ZW9rUWw=
 github.com/SKF/go-utility/v2 v2.25.3 h1:IEpOzSU8y3db+MkvMKJe2XjLWmdaaMP8X7bf9EXgc4k=
 github.com/SKF/go-utility/v2 v2.25.3/go.mod h1:uHFUYZL5p9HYstelDwQBuKV1NzzKS6i5xlV8l2BlFmc=
+github.com/SKF/go-utility/v2 v2.29.0 h1:qB0oitZTwEql9ndFojF4rQP9k7d53O6Pss7Laf0DiO0=
+github.com/SKF/go-utility/v2 v2.29.0/go.mod h1:Nd3wuNk43YqfIYrOlxkwYjaEZwHMoOGm89cKk/ntnfU=
 github.com/SKF/proto v1.21.0-go h1:l4nbV3lqmcwHMJ4pn00/1KUtzgDdHEoK9fmCOsPj3oQ=
 github.com/SKF/proto v1.21.0-go/go.mod h1:fLZMzpComrKyD9V74fS1lT4ryHZX9LlYYjM1TmBZw+s=
 github.com/SKF/proto/v2 v2.4.1-go/go.mod h1:l4Wu+tc9SHy8qdecDR0BZCzg/i3+Nn436TjIQzOASTM=

--- a/problems.go
+++ b/problems.go
@@ -22,13 +22,6 @@ func (p *ProblemDecoder) DecodeProblem(ctx context.Context, r *http.Response) (p
 		)
 
 		return problem, err
-	case http.StatusInternalServerError:
-		var (
-			problem = problems.InternalProblem{}
-			err     = decoder.Decode(&problem)
-		)
-
-		return problem, err
 	default:
 		var (
 			problem = problems.BasicProblem{}


### PR DESCRIPTION
When receiving a 500 Internal Server Error response the problem decoder would try to decode that into a problems.InternalProblem. This problem struct will try to use the wrapped error cause when producing a formatted error message. Since this field is excluded when marshaling the struct it will be nil when decoding to it, cause a nil pointer panic to be printed in the error message.

Decode these issues to a problems.BasicProblem instead.